### PR TITLE
Package conflicts in barometer build

### DIFF
--- a/build/overcloud-full.sh
+++ b/build/overcloud-full.sh
@@ -150,7 +150,7 @@ LIBGUESTFS_BACKEND=direct $VIRT_CUSTOMIZE \
     -a overcloud-full_build.qcow2
 
     # upload and install barometer packages
-    barometer_pkgs overcloud-full_build.qcow2
+    #barometer_pkgs overcloud-full_build.qcow2
 
 fi # end x86_64 specific items
 


### PR DESCRIPTION
"Error: Package: collectd-write_sensu-5.8.0-3.el7.x86_64 (@quickstart-centos-opstools)", "           Requires: collectd(x86-64) = 5.8.0-3.el7", "           Removing: collectd-5.8.0-3.el7.x86_64 (@quickstart-centos-opstools)", "               collectd(x86-64) = 5.8.0-3.el7", "           Updated By: collectd-5.8.0.72.g9fa9887-8.el7.centos.x86_64 (/collectd-5.8.0.72.g9fa9887-8.el7.centos.x86_64)", "               collectd(x86-64) = 5.8.0.72.g9fa9887-8.el7.centos", " You could try using --skip-broken to work around the problem", " You could try running: rpm -Va --nofiles --nodigest",